### PR TITLE
fixed dropdown resizing issues and updated artist input position

### DIFF
--- a/src/lib/components/ArtistSearchDropdown.svelte
+++ b/src/lib/components/ArtistSearchDropdown.svelte
@@ -9,8 +9,8 @@
     const dispatch = createEventDispatcher();
     
     // Calculate responsive dropdown offset - using very small fixed value
-    $: dropdownOffset = 2; // Very small fixed offset
-    $: dropdownMaxHeight = windowHeight ? windowHeight * 0.25 : 200; // 25% of window height, fallback 200px
+    $: dropdownOffset = windowHeight * 0.028; // Very small fixed offset
+    $: dropdownMaxHeight = windowHeight * 0.25; // 25% of window height, fallback 200px
     
     // Calculate responsive dropdown item dimensions
     $: itemPaddingVertical = windowHeight ? windowHeight * 0.008 : 8; // 0.8% of window height, fallback 8px
@@ -347,13 +347,12 @@
         align-items: center;
         height: 100%;
         width: 100%;
-        min-height: 30px;
         cursor: text;
     }
     
     .visual-text {
         position: absolute;
-        left: var(--text-left-offset, 4px);
+        left: var(--item-padding-horizontal, 4px);
         top: 50%;
         transform: translateY(-50%);
         font-size: var(--search-font-size, inherit);

--- a/src/lib/components/TypingTest.svelte
+++ b/src/lib/components/TypingTest.svelte
@@ -540,7 +540,7 @@
          border: 2px solid var(--primary-color);
          background-color: var(--secondary-color);
          border-radius: 4px;
-         padding: 0 12px;
+         /* padding: 0 12px; */
          flex: 1;
      }
 


### PR DESCRIPTION
This pull request includes several updates to improve the responsiveness and maintainability of styles in the `ArtistSearchDropdown` and `TypingTest` components. The most important changes involve updating dropdown calculations to be more dynamic, adjusting CSS variables for consistency, and commenting out unused padding styles.

### Updates to `ArtistSearchDropdown`:

* Made dropdown offset and max height calculations fully dynamic by removing fallback values and basing them directly on `windowHeight`. This improves responsiveness for various screen sizes. (`src/lib/components/ArtistSearchDropdown.svelte`, [src/lib/components/ArtistSearchDropdown.svelteL12-R13](diffhunk://#diff-e2045259b8a28154d98bade6c8ab7d7d730acda835f33c9219180fca5c016e19L12-R13))
* Updated CSS to replace `--text-left-offset` with `--item-padding-horizontal` for better consistency in naming and alignment with other padding variables. (`src/lib/components/ArtistSearchDropdown.svelte`, [src/lib/components/ArtistSearchDropdown.svelteL350-R355](diffhunk://#diff-e2045259b8a28154d98bade6c8ab7d7d730acda835f33c9219180fca5c016e19L350-R355))

### Updates to `TypingTest`:

* Commented out unused padding in the CSS for the main container to simplify styling and avoid redundant declarations. (`src/lib/components/TypingTest.svelte`, [src/lib/components/TypingTest.svelteL543-R543](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bL543-R543))